### PR TITLE
add -v flag to add docstring (does nothing)

### DIFF
--- a/qaueue/views.py
+++ b/qaueue/views.py
@@ -24,7 +24,7 @@ USAGE = '''
 QAueue: /qaueue manages the items in the QA pipeline
 
 Usage:
-    /qaueue [-q] add <item>
+    /qaueue [-q] [-v] add <item>
     /qaueue [-v] help [<help_command>]
     /qaueue [-v] list
     /qaueue [-v] prioritize <prioritize_item_id> <priority_index>


### PR DESCRIPTION
add a noop `-v` flag to the docstring for the `add` command. this prevents 502 errors when accidentally including it, since `add` defaults to posting the response in channel