### PR TITLE
Make update command verbose by default

### DIFF
--- a/qaueue/slack.py
+++ b/qaueue/slack.py
@@ -11,8 +11,8 @@ from aioredis import Redis
 
 def message_body(args: dict = None, **kwargs) -> dict:
     defaults = {}
-    if args.get('add', False):
-        # Special case, `/qaueue add` has 'response_type' set to 'in_channel' by default
+    if args.get('add', False) or args.get('update', False):
+        # Special cases, `/qaueue (add|update)` have 'response_type' set to 'in_channel' by default
         # and 'ephemeral' only if the `-q` flag is used
         is_quiet = args.get('-q', False)
         if is_quiet:

--- a/qaueue/views.py
+++ b/qaueue/views.py
@@ -312,8 +312,6 @@ async def set_item_status(conn: aioredis.Redis, args: dict, config: Config) -> w
     item.status = new_status
     error = None
     if new_status == statuses.COMPLETED:
-        # override the '-v' flag arg when new_status is the completed status ('released')
-        args['-v'] = True
         error = await _complete_item(item)
     await item.update()
     item = await db.Item.get(item_id=item.item_id)

--- a/qaueue/views.py
+++ b/qaueue/views.py
@@ -24,13 +24,13 @@ USAGE = '''
 QAueue: /qaueue manages the items in the QA pipeline
 
 Usage:
-    /qaueue [-q] [-v] add <item>
+    /qaueue [-qv] add <item>
     /qaueue [-v] help [<help_command>]
     /qaueue [-v] list
     /qaueue [-v] prioritize <prioritize_item_id> <priority_index>
     /qaueue [-v] remove <remove_item_id>
     /qaueue [-v] status <status_item_id>
-    /qaueue [-v] update <update_item_id> <status>
+    /qaueue [-qv] update <update_item_id> <status>
 
 Options:
     -v    Make the output of the command visible to the channel

--- a/qaueue/views.py
+++ b/qaueue/views.py
@@ -312,6 +312,8 @@ async def set_item_status(conn: aioredis.Redis, args: dict, config: Config) -> w
     item.status = new_status
     error = None
     if new_status == statuses.COMPLETED:
+        # override the '-v' flag arg when new_status is the completed status ('released')
+        args['-v'] = True
         error = await _complete_item(item)
     await item.update()
     item = await db.Item.get(item_id=item.item_id)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -219,6 +219,7 @@ async def test_update_to_defined_status(qaueue_command: QaueueCommandClient, rea
     await item.reload()
     assert item.status == new_status
     assert resp_json['attachments'][0]['color'] == colors.GREEN
+    assert resp_json['response_type'] == 'in_channel'
 
 
 async def test_update_to_undefined_status(qaueue_command: QaueueCommandClient, read_only_config: Config,
@@ -231,6 +232,7 @@ async def test_update_to_undefined_status(qaueue_command: QaueueCommandClient, r
     await item.reload()
     assert item.status == new_status
     assert resp_json['attachments'][0]['color'] == colors.GREEN
+    assert resp_json['response_type'] == 'in_channel'
 
 
 async def test_update_to_released_status_no_v_flag(qaueue_command: QaueueCommandClient, read_only_config: Config,
@@ -263,6 +265,19 @@ async def test_update_to_released_status_with_v_flag(qaueue_command: QaueueComma
     await item.reload()
     assert item.status == new_status
     assert resp_json['response_type'] == 'in_channel'
+
+
+async def test_update_status_with_q_flag(qaueue_command: QaueueCommandClient, read_only_config: Config,
+                                         mock_get_story: typing.Callable[[int], dict]):
+    url, story_id = fake_pivotal_story()
+    mock_story = mock_get_story(story_id)
+    item = await db.Item.create(url=url, name=mock_story['name'])
+    new_status = 'integration'
+    resp_json = await qaueue_command(f'update 0 {new_status}')
+    await item.reload()
+    assert item.status == new_status
+    assert resp_json['response_type'] == 'in_channel'
+    assert resp_json['attachments'][0]['color'] == colors.GREEN
 
 
 async def test_list_item_with_updated_defined_status(qaueue_command: QaueueCommandClient, read_only_config: Config,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -233,6 +233,38 @@ async def test_update_to_undefined_status(qaueue_command: QaueueCommandClient, r
     assert resp_json['attachments'][0]['color'] == colors.GREEN
 
 
+async def test_update_to_released_status_no_v_flag(qaueue_command: QaueueCommandClient, read_only_config: Config,
+                                                   mock_get_story: typing.Callable[[int], dict],
+                                                   mock_add_label_to_story):
+    '''
+    tests that the response_type for 'update X released' is 'in_channel' when '-v' flag is excluded
+    '''
+    url, story_id = fake_pivotal_story()
+    mock_story = mock_get_story(story_id)
+    item = await db.Item.create(url=url, name=mock_story['name'])
+    new_status = 'released'
+    resp_json = await qaueue_command(f'update 0 {new_status}')
+    await item.reload()
+    assert item.status == new_status
+    assert resp_json['response_type'] == 'in_channel'
+
+
+async def test_update_to_released_status_with_v_flag(qaueue_command: QaueueCommandClient, read_only_config: Config,
+                                                     mock_get_story: typing.Callable[[int], dict],
+                                                     mock_add_label_to_story):
+    '''
+    tests that the response_type for 'update X released' is 'in_channel' when '-v' flag is included
+    '''
+    url, story_id = fake_pivotal_story()
+    mock_story = mock_get_story(story_id)
+    item = await db.Item.create(url=url, name=mock_story['name'])
+    new_status = 'released'
+    resp_json = await qaueue_command(f'update 0 {new_status}')
+    await item.reload()
+    assert item.status == new_status
+    assert resp_json['response_type'] == 'in_channel'
+
+
 async def test_list_item_with_updated_defined_status(qaueue_command: QaueueCommandClient, read_only_config: Config,
                                                      mock_get_story: typing.Callable[[int], dict]):
     url, story_id = fake_pivotal_story()


### PR DESCRIPTION
Makes the `/qaueue update` command verbose by default. This means that the response is visible to the whole channel, not just the user who issued the command. Should help to keep everyone in the loop on whats going out better.